### PR TITLE
修复在隐藏表头的情况下，表格最后一行的固定列会跟随表格滑动的bug

### DIFF
--- a/uni_modules/zb-table/components/zb-table/zb-table.vue
+++ b/uni_modules/zb-table/components/zb-table/zb-table.vue
@@ -188,7 +188,7 @@
             @scroll="leftFixedScrollAction"
             :scroll-top="leftFiexScrollTop"
             class="zb-table-body-inner"
-            :style=" `height: calc(100% - ${showSummary?80:40}px)`">
+            :style=" `height: calc(100% - ${showSummary?80:40} - ${showHeader?0:40}px)`">
           <view class="zb-table-fixed">
             <view class="zb-table-tbody">
               <view


### PR DESCRIPTION
当前的版本，在隐藏表头的情况下，表格最后一行的固定列会跟随表格滑动。